### PR TITLE
Adjustments to websocket sharp to support the ability to keep track websocket statistics

### DIFF
--- a/websocket-sharp/Server/WebSocketBehavior.cs
+++ b/websocket-sharp/Server/WebSocketBehavior.cs
@@ -511,7 +511,7 @@ namespace WebSocketSharp.Server
 
     private void onOpen (object sender, EventArgs e)
     {
-      _id = _sessions.Add (this);
+      _id = _sessions.Add (this, UserEndPoint?.Address?.ToString());
 
       if (_id == null) {
         _websocket.Close (CloseStatusCode.Away);

--- a/websocket-sharp/Server/WebSocketSessionManager.cs
+++ b/websocket-sharp/Server/WebSocketSessionManager.cs
@@ -31,9 +31,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
+
 using System.Threading;
-using System.Timers;
+
+using WebSocketSharp.Server;
 
 namespace WebSocketSharp.Server
 {
@@ -58,6 +59,7 @@ namespace WebSocketSharp.Server
     private System.Timers.Timer                   _sweepTimer;
     private object                                _sync;
     private TimeSpan                              _waitTime;
+    private WebsocketStatsManager                 _statsManager;
 
     #endregion
 
@@ -82,6 +84,7 @@ namespace WebSocketSharp.Server
       _state = ServerState.Ready;
       _sync = ((ICollection) _sessions).SyncRoot;
       _waitTime = TimeSpan.FromSeconds (5);
+      _statsManager = new WebsocketStatsManager(log);
 
       setSweepTimer (180000);
     }
@@ -460,7 +463,7 @@ namespace WebSocketSharp.Server
 
     #region Internal Methods
 
-    internal string Add (IWebSocketSession session)
+    internal string Add (IWebSocketSession session, string ipAddress)
     {
       lock (_sync) {
         if (_state != ServerState.Start)
@@ -470,7 +473,8 @@ namespace WebSocketSharp.Server
 
         _sessions.Add (id, session);
 
-        _log.Trace($"Adding new socket session with ID - {id}");
+         _log.Trace($"Adding new socket session for IP {ipAddress} -  {id}");
+        _statsManager.AddUniqueConnection(ipAddress);
 
         return id;
       }
@@ -1554,9 +1558,7 @@ namespace WebSocketSharp.Server
         _sweeping = true;
       }
 
-      var connectedSessions = IDs.ToArray();
-      if(connectedSessions.Length > 0) 
-        _log.Trace($"Connected sessions: {string.Join(",", connectedSessions)}");
+      _log.Trace($"Number of connected sessions - {IDs.Count()}");
 
       foreach (var id in InactiveIDs) {
         if (_state != ServerState.Start)

--- a/websocket-sharp/Server/WebsocketStatsManager.cs
+++ b/websocket-sharp/Server/WebsocketStatsManager.cs
@@ -1,0 +1,95 @@
+﻿using Microsoft.Win32;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Timers;
+
+namespace WebSocketSharp.Server
+{
+    internal class WebsocketStatsManager
+    {
+
+        private HashSet<string> _uniqueConnections;
+        private DailyTimer _statsTimer;
+        private Logger _log;
+
+        public WebsocketStatsManager(Logger log)
+        {
+            _log = log;
+            _uniqueConnections = new HashSet<string>();
+
+            //Indicates that the timer will elapse at 00:00:00 of the next day (Midnight)
+            _statsTimer = new DailyTimer(new TimeSpan(0));
+
+            _statsTimer.Elapsed -= _statsTimer_Elapsed;
+            _statsTimer.Elapsed += _statsTimer_Elapsed;
+            _statsTimer.Start();
+        }
+
+        private void _statsTimer_Elapsed(object sender, EventArgs e)
+        {
+            if (_uniqueConnections != null)
+            {
+                _log.Trace($"Number of unique connections over the past 24 hours - {_uniqueConnections.Count}");
+                _log.Trace($"Unique IP's connected over the past 24 hours - {string.Join(",", _uniqueConnections.ToArray())}");
+            }
+            _uniqueConnections.Clear();
+        }
+
+        public void AddUniqueConnection(string ipAddress)
+        {
+            if (!string.IsNullOrEmpty(ipAddress))
+            {
+                if (_uniqueConnections == null)
+                {
+                    _uniqueConnections = new HashSet<string>();
+                }
+                _uniqueConnections.Add(ipAddress);
+            }
+        }
+
+        internal class DailyTimer
+        {
+            internal event EventHandler Elapsed = delegate { };
+            private Timer timer;
+            private DateTime previousRun;
+            private TimeSpan elapseTimeSpan;
+
+            internal DailyTimer(TimeSpan elapseTime)
+            {
+                timer = new Timer();
+                timer.AutoReset = false;
+                timer.Elapsed += ElapsedTimer;
+
+                elapseTimeSpan = elapseTime;
+            }
+
+            internal void Start()
+            {
+                previousRun = DateTime.Today;
+
+                TimeSpan timeSpanToElapsed = GetNextDay().Subtract(DateTime.Now);
+                timer.Interval = timeSpanToElapsed.TotalMilliseconds;
+                timer.Start();
+            }
+
+            private void ElapsedTimer(object sender, ElapsedEventArgs e)
+            {
+                if (previousRun != DateTime.Today)
+                    Elapsed(this, EventArgs.Empty);
+
+                timer.Stop();
+                Start();
+            }
+
+            private DateTime GetNextDay()
+            {
+                return DateTime.Today.AddDays(1).Add(elapseTimeSpan);
+            }
+        }
+
+
+
+
+    }
+}

--- a/websocket-sharp/websocket-sharp.csproj
+++ b/websocket-sharp/websocket-sharp.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -72,6 +72,7 @@
     <Compile Include="CloseEventArgs.cs" />
     <Compile Include="ByteOrder.cs" />
     <Compile Include="ErrorEventArgs.cs" />
+    <Compile Include="Server\WebsocketStatsManager.cs" />
     <Compile Include="WebSocket.cs" />
     <Compile Include="Server\WebSocketServer.cs" />
     <Compile Include="Net\AuthenticationSchemes.cs" />
@@ -146,9 +147,5 @@
     <Compile Include="Server\WebSocketServiceHost`1.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-  <ItemGroup>
-    <Folder Include="Server\" />
-    <Folder Include="Net\" />
-    <Folder Include="Net\WebSockets\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
Adjustments to websocket sharp to support the ability to keep track websocket statistics.

This implements base logic for a WebsocketStatsManager, which we can extend further in the future with more in-depth metrics.

Logging will run on both HTTP and Websocket server.