### PR TITLE
Ability to configure Websocket Stream timeout

### DIFF
--- a/websocket-sharp/Net/WebSockets/TcpListenerWebSocketContext.cs
+++ b/websocket-sharp/Net/WebSockets/TcpListenerWebSocketContext.cs
@@ -63,6 +63,7 @@ namespace WebSocketSharp.Net.WebSockets
     private IPrincipal          _user;
     private System.Net.EndPoint _userEndPoint;
     private WebSocket           _websocket;
+    private TimeSpan            _socketTimeout;
 
     #endregion
 
@@ -73,12 +74,14 @@ namespace WebSocketSharp.Net.WebSockets
       string protocol,
       bool secure,
       ServerSslConfiguration sslConfig,
-      Logger log
+      Logger log,
+      TimeSpan socketTimeout
     )
     {
       _tcpClient = tcpClient;
       _secure = secure;
       _log = log;
+      _socketTimeout = socketTimeout;
 
       var netStream = tcpClient.GetStream ();
 
@@ -427,6 +430,18 @@ namespace WebSocketSharp.Net.WebSockets
     public override WebSocket WebSocket {
       get {
         return _websocket;
+      }
+    }
+
+    /// <summary>
+    /// Gets the Websocket Timeout used for the underlying TCP Client Stream
+    /// for the websocket server.
+    /// </summary>
+    public TimeSpan SocketTimeout
+    {
+      get
+      {
+        return _socketTimeout;
       }
     }
 

--- a/websocket-sharp/Server/WebSocketServer.cs
+++ b/websocket-sharp/Server/WebSocketServer.cs
@@ -79,7 +79,11 @@ namespace WebSocketSharp.Server
     private object                             _sync;
     private Func<IIdentity, NetworkCredential> _userCredFinder;
 
+    //Default TCP socket timeout to 5 seconds instead of infinite
+    private TimeSpan                           _socketTCPTimeout = TimeSpan.FromSeconds(5);
+
     public static int                          _hostPort;
+
 
     #endregion
 
@@ -652,6 +656,32 @@ namespace WebSocketSharp.Server
     }
 
     /// <summary>
+    /// Gets or sets the Socket Timeout to be used for the underlying
+    /// TCP Client Stream for the server's access of the clients socket.
+    /// </summary>
+    /// <remarks>
+    /// Required to allow concurrent data flow during periods of connectivity
+    /// issues
+    /// </remarks>
+    /// <value>
+    ///   <para>
+    ///   A <see cref="TimeSpan"/> that represents the time to wait for
+    ///   the response.
+    ///   </para>
+    ///   <para>
+    ///   The default value is the same as 1 second.
+    ///   </para>
+    /// </value>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The value specified for a set operation is zero or less.
+    /// </exception>
+    public TimeSpan SocketTCPTimeout
+    {
+        get => _socketTCPTimeout;
+        set => _socketTCPTimeout = value;
+    }
+
+    /// <summary>
     /// Gets the management function for the WebSocket services provided by
     /// the server.
     /// </summary>
@@ -836,7 +866,7 @@ namespace WebSocketSharp.Server
             state => {
               try {
                 var ctx = new TcpListenerWebSocketContext (
-                            cl, null, _secure, _sslConfigInUse, _log
+                            cl, null, _secure, _sslConfigInUse, _log, _socketTCPTimeout
                           );
 
                 processRequest (ctx);

--- a/websocket-sharp/Server/WebSocketServiceManager.cs
+++ b/websocket-sharp/Server/WebSocketServiceManager.cs
@@ -62,7 +62,7 @@ namespace WebSocketSharp.Server
       _keepClean = true;
       _state = ServerState.Ready;
       _sync = ((ICollection) _hosts).SyncRoot;
-      _waitTime = TimeSpan.FromSeconds (5);
+      _waitTime = TimeSpan.FromSeconds (1);
     }
 
     #endregion

--- a/websocket-sharp/WebSocket.cs
+++ b/websocket-sharp/WebSocket.cs
@@ -177,7 +177,10 @@ namespace WebSocketSharp
       _message = messages;
       _secure = context.IsSecureConnection;
       _stream = context.Stream;
-      _waitTime = TimeSpan.FromSeconds (1);
+      _waitTime = TimeSpan.FromSeconds(1);
+
+      _stream.WriteTimeout = (int)TimeSpan.FromSeconds(5).TotalMilliseconds;
+      _stream.ReadTimeout = (int)TimeSpan.FromSeconds(5).TotalMilliseconds;
 
       init ();
     }
@@ -193,7 +196,11 @@ namespace WebSocketSharp
       _message = messages;
       _secure = context.IsSecureConnection;
       _stream = context.Stream;
+
       _waitTime = TimeSpan.FromSeconds (1);
+
+      _stream.WriteTimeout = (int)context.SocketTimeout.TotalMilliseconds;
+      _stream.ReadTimeout = (int)context.SocketTimeout.TotalMilliseconds;
 
       init ();
     }
@@ -2136,8 +2143,9 @@ namespace WebSocketSharp
         _stream.Write (bytes, 0, bytes.Length);
       }
       catch (Exception ex) {
-        _log.Error (ex.Message);
-        _log.Debug (ex.ToString ());
+        _log.Trace($"Exception while attempting to send to {ClientIP}");
+        _log.Trace(ex.Message);
+        _log.Trace(ex.ToString ());
 
         return false;
       }


### PR DESCRIPTION
Enhanced websocket sharp handling to prevent performance degradation during periods of increased client latency.

Issue being that when performing broadcasts synchronously websocket sharp will wait indefinitely until the write can complete. This is due to it using the default TCP Client timeout which is indefinite. These changes expose the ability to define the Read and Write timeout for the underlying TCP Client Stream to allow better performance (ideally async broadcast would be used in most situations).

Adding verbosity to logging to allow better logging of Sweep and Ping/Pong mechanisms, including client IP.